### PR TITLE
Pass field name API expects

### DIFF
--- a/lib/Net/Easypost/CustomsInfo.pm
+++ b/lib/Net/Easypost/CustomsInfo.pm
@@ -79,7 +79,7 @@ sub serialize {
    if ($self->customs_items) {
        foreach my $i (0 .. $#{ $self->customs_items }) {
 	   my $item = $self->customs_items->[$i];
-	   $obj->{$self->role . "[" . $item->role . "][$i][id]"} = $item->id;
+	   $obj->{$self->role . "[customs_items][$i][id]"} = $item->id;
        }
    }
 


### PR DESCRIPTION
role() returns the singular "customs_item" where the API expects
"customs_items"