### PR TITLE
Include Shipment's options field when serializing

### DIFF
--- a/lib/Net/Easypost/Shipment.pm
+++ b/lib/Net/Easypost/Shipment.pm
@@ -75,6 +75,9 @@ sub serialize {
 
    # want a hashref of e.g., shipment[to_address][id] => foo from all defined attributes
    return {
+       (defined $self->options
+        ? map { $self->role . "[options][$_]" => $self->options->{$_} } %{$self->options}
+        : ()),
        map { $self->role . "[$_][id]" => $self->$_->id }
        grep { defined $self->$_ }
           qw(to_address from_address parcel customs_info)


### PR DESCRIPTION
Net::Easypost::Shipment has an options field, but it isn't included in `serialize`, so it gets left out of the API call.  This patch adds it in (if defined).

Here's how I'm using it to get a label in my label printer's format instead of the PNG default:

```perl
my $shipment = Net::Easypost::Shipment->new(
    from_address => $from,
    to_address => $to,
    parcel => $parcel,
    options => {
        label_format => 'ZPL',
    },
);
```